### PR TITLE
fix handling of filesystems on disks without partitions

### DIFF
--- a/app/src/main/java/com/morlunk/mountie/fs/Partition.java
+++ b/app/src/main/java/com/morlunk/mountie/fs/Partition.java
@@ -29,11 +29,14 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Created by andrew on 14/09/14.
  */
 public class Partition extends BlockDevice {
+    private static final Pattern HAS_LOGICAL_ID_PATTERN = Pattern.compile("(sd[a-z]+)(\\d+)");
     private Set<Mount> mMounts;
     private String mLabel;
     private String mUUID;
@@ -120,10 +123,15 @@ public class Partition extends BlockDevice {
     }
 
     public String getVolumeName() {
-        return getName().replaceAll("(sd[a-z]+)[0-9]+", "$1");
+        return getName().replaceAll("(sd[a-z]+)[0-9]*", "$1");
     }
 
     public int getLogicalId() {
-        return Integer.parseInt(getName().replaceAll("sd[a-z]+([0-9]+)", "$1"));
+        Matcher matcher = HAS_LOGICAL_ID_PATTERN.matcher(getName());
+        if (matcher.matches()) {
+            return Integer.parseInt(getName().replaceAll("sd[a-z]+([0-9]+)", "$1"));
+        } else {
+            return 0;
+        }
     }
 }

--- a/app/src/main/java/com/morlunk/mountie/fs/Partition.java
+++ b/app/src/main/java/com/morlunk/mountie/fs/Partition.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  * Created by andrew on 14/09/14.
  */
 public class Partition extends BlockDevice {
-    private static final Pattern HAS_LOGICAL_ID_PATTERN = Pattern.compile("(sd[a-z]+)(\\d+)");
+    private static final Pattern LOGICAL_ID_PATTERN = Pattern.compile("sd[a-z]+(\\d+)");
     private Set<Mount> mMounts;
     private String mLabel;
     private String mUUID;
@@ -127,9 +127,9 @@ public class Partition extends BlockDevice {
     }
 
     public int getLogicalId() {
-        Matcher matcher = HAS_LOGICAL_ID_PATTERN.matcher(getName());
+        Matcher matcher = LOGICAL_ID_PATTERN.matcher(getName());
         if (matcher.matches()) {
-            return Integer.parseInt(getName().replaceAll("sd[a-z]+([0-9]+)", "$1"));
+            return Integer.parseInt(matcher.group(1));
         } else {
             return 0;
         }


### PR DESCRIPTION
Filesystem can be on whole disk, e.g. on /dev/sda, instead of /dev/sda1.
