### PR TITLE
add button to manually call mBlockDeviceObserver.detectDevices();

### DIFF
--- a/app/src/main/java/com/morlunk/mountie/MountieActivity.java
+++ b/app/src/main/java/com/morlunk/mountie/MountieActivity.java
@@ -84,8 +84,7 @@ public class MountieActivity extends Activity {
     }
 
     public void onClickDetectDevices(View v) {
-        if (mMountieService != null)
-        {
+        if (mMountieService != null) {
             mMountieService.detectDevices();
         }
     }

--- a/app/src/main/java/com/morlunk/mountie/MountieActivity.java
+++ b/app/src/main/java/com/morlunk/mountie/MountieActivity.java
@@ -26,18 +26,21 @@ import android.os.Bundle;
 import android.os.IBinder;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 
 
 public class MountieActivity extends Activity {
+    private MountieService mountieService;
+
     private ServiceConnection mConn = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName name, IBinder service) {
-
+            mountieService = ((MountieService.LocalBinder)service).getService();
         }
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
-
+            mountieService = null;
         }
     };
 
@@ -78,5 +81,16 @@ public class MountieActivity extends Activity {
 //            return true;
 //        }
         return super.onOptionsItemSelected(item);
+    }
+
+    public void onClickDetectDevices(View v) {
+        if (mountieService != null)
+        {
+            mountieService.detectDevices();
+        }
+        else
+        {
+            // TODO
+        }
     }
 }

--- a/app/src/main/java/com/morlunk/mountie/MountieActivity.java
+++ b/app/src/main/java/com/morlunk/mountie/MountieActivity.java
@@ -30,17 +30,17 @@ import android.view.View;
 
 
 public class MountieActivity extends Activity {
-    private MountieService mountieService;
+    private MountieService mMountieService;
 
     private ServiceConnection mConn = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName name, IBinder service) {
-            mountieService = ((MountieService.LocalBinder)service).getService();
+            mMountieService = ((MountieService.LocalBinder)service).getService();
         }
 
         @Override
         public void onServiceDisconnected(ComponentName name) {
-            mountieService = null;
+            mMountieService = null;
         }
     };
 
@@ -84,9 +84,9 @@ public class MountieActivity extends Activity {
     }
 
     public void onClickDetectDevices(View v) {
-        if (mountieService != null)
+        if (mMountieService != null)
         {
-            mountieService.detectDevices();
+            mMountieService.detectDevices();
         }
         else
         {

--- a/app/src/main/java/com/morlunk/mountie/MountieActivity.java
+++ b/app/src/main/java/com/morlunk/mountie/MountieActivity.java
@@ -88,9 +88,5 @@ public class MountieActivity extends Activity {
         {
             mMountieService.detectDevices();
         }
-        else
-        {
-            // TODO
-        }
     }
 }

--- a/app/src/main/java/com/morlunk/mountie/MountieService.java
+++ b/app/src/main/java/com/morlunk/mountie/MountieService.java
@@ -171,4 +171,8 @@ public class MountieService extends Service implements MountieNotification.Liste
             return mService;
         }
     }
+
+    public void detectDevices() {
+        mBlockDeviceObserver.detectDevices();
+    }
 }

--- a/app/src/main/res/layout/activity_mountie.xml
+++ b/app/src/main/res/layout/activity_mountie.xml
@@ -30,6 +30,16 @@
         android:text="@string/mountie_instructions"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:textAppearanceMedium"/>
+        android:textAppearance="?android:textAppearanceMedium"
+        android:id="@+id/textView" />
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/detect_devices"
+        android:id="@+id/button"
+        android:onClick="onClickDetectDevices"
+        android:layout_below="@+id/textView"
+        android:layout_centerHorizontal="true" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,5 +38,6 @@
     <string name="notify_label">Label: %s</string>
     <string name="notify_uuid">UUID: %s</string>
     <string name="notify_dev">Device: %s</string>
+    <string name="detect_devices">Detect Devices</string>
 
 </resources>


### PR DESCRIPTION
This allows to mount devices when FileObserver doesn't work on /dev/
filesystem (e.g. on Android 5.1.1 on Nexus 5).

Also this allows to remount devices when they were manually unmounted.
